### PR TITLE
fix middleware - throw 404 if already installed

### DIFF
--- a/src/Providers/LaravelInstallerServiceProvider.php
+++ b/src/Providers/LaravelInstallerServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Froiden\LaravelInstaller\Providers;
 
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Froiden\LaravelInstaller\Middleware\canInstall;
 
 class LaravelInstallerServiceProvider extends ServiceProvider
 {
@@ -28,11 +30,12 @@ class LaravelInstallerServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application events.
      *
+     * @param \Illuminate\Routing\Router $router
      * @return void
      */
-    public function boot()
+    public function boot(Router $router)
     {
-        app('router')->middleware('canInstall', '\Froiden\LaravelInstaller\Middleware\canInstall');
+        $router->middlewareGroup('install', [canInstall::class]);
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,6 +1,6 @@
 <?php
     include 'functions.php';
-Route::group(['prefix' => 'install', 'as' => 'LaravelInstaller::', 'namespace' => 'Froiden\LaravelInstaller\Controllers', 'middleware' => 'web','install'], function()
+Route::group(['prefix' => 'install', 'as' => 'LaravelInstaller::', 'namespace' => 'Froiden\LaravelInstaller\Controllers', 'middleware' => ['web', 'install']], function()
 {
     Route::get('/', [
             'as' => 'welcome',


### PR DESCRIPTION
If someone could try this, that'd be great. It should fix the issue of where a 404 would not get thrown when accessing the install route, even though it was already installed.