### PR TITLE
Fix Installer Crash and Add Session Handling

### DIFF
--- a/src/Helpers/DatabaseManager.php
+++ b/src/Helpers/DatabaseManager.php
@@ -7,11 +7,9 @@ use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class DatabaseManager
 {
-
     /**
      * Migrate and seed the database.
      *
@@ -20,6 +18,7 @@ class DatabaseManager
     public function migrateAndSeed()
     {
         $this->sqlite();
+
         return $this->migrate();
     }
 
@@ -31,7 +30,7 @@ class DatabaseManager
     private function migrate()
     {
         try {
-            Artisan::call('migrate:fresh', ["--force" => true, '--schema-path' => 'do not run schema path']);
+            Artisan::call('migrate:fresh', ['--force' => true, '--schema-path' => 'do not run schema path']);
         } catch (Exception $e) {
             return $this->response($e->getMessage());
         }
@@ -52,22 +51,32 @@ class DatabaseManager
             return $this->response($e->getMessage());
         }
 
-        return $this->response(trans('installer_messages.final.finished'), 'success');
+        // Prepare a success message using translations
+        $response_message = trans('installer_messages.final.finished');
+
+        // Set the success message in the session for later use in the view
+        session([
+            'installer' => [
+                'message' => $response_message,
+                'status' => 'success',
+            ],
+        ]);
+
+        return $this->response($response_message, 'success');
     }
 
     /**
      * Return a formatted error messages.
      *
-     * @param $message
-     * @param string $status
+     * @param  string  $status
      * @return array
      */
     private function response($message, $status = 'danger')
     {
-        return array(
+        return [
             'status' => $status,
-            'message' => $message
-        );
+            'message' => $message,
+        ];
     }
 
     /**
@@ -77,7 +86,7 @@ class DatabaseManager
     {
         if (DB::connection() instanceof SQLiteConnection) {
             $database = DB::connection()->getDatabaseName();
-            if (!file_exists($database)) {
+            if (! file_exists($database)) {
                 touch($database);
                 DB::reconnect(Config::get('database.default'));
             }

--- a/src/Views/finished.blade.php
+++ b/src/Views/finished.blade.php
@@ -2,7 +2,9 @@
 
 @section('title', trans('installer_messages.final.title'))
 @section('container')
-    <p class="paragraph" style="text-align: center;">{{ session('message')['message'] }}</p>
+    <p class="paragraph" style="text-align: center; color: #0b9b5d">
+        {{ session('installer')['message'] ?? trans('installer_messages.final.finished') }}
+    </p>
     <div class="buttons">
         <a href="{{ url('/') }}" class="button">{{ trans('installer_messages.final.exit') }}</a>
     </div>


### PR DESCRIPTION
This pull request includes several changes to the `DatabaseManager` class and the `finished.blade.php` view to improve database migration and seeding functionality, as well as enhance the user interface.

### DatabaseManager Enhancements:

* Removed the unused `Log` facade import from `DatabaseManager.php`.
* Added a blank line in the `migrateAndSeed` method for better readability.
* Corrected the formatting of the `Artisan::call` method parameters in the `migrate` function.
* Improved the `seed` function to set a success message in the session for later use in the view.
* Updated the `response` method to use array shorthand syntax.

### View Enhancements:

* Modified `finished.blade.php` to display the installer message from the session with a default fallback and added inline styling for better visual feedback.

**Enhancements:**
- Added session message for database seeding success in the `DatabaseManager` class.
- Updated the `finished.blade.php` view to handle missing session messages gracefully, preventing crashes.

---

### **Code Changes:**  

1. **Session Message Added in `DatabaseManager` Class:**  
```php
// Prepare a success message using translations
$response_message = trans('installer_messages.final.finished');

// Set the success message in the session for later use in the view
session([
    'installer' => [
        'message' => $response_message,
        'status' => 'success',
    ],
]);

return $this->response($response_message, 'success');
```

2. **View Updated to Prevent Crash in `finished.blade.php`:**  
```blade
<p class="paragraph" style="text-align: center; color: #0b9b5d">
    {{ session('installer')['message'] ?? trans('installer_messages.final.finished') }}
</p>
``` 

This ensures better user feedback and stability during the installation process.